### PR TITLE
asciitree 0.3.3 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,38 +1,43 @@
+{% set name = "asciitree" %}
 {% set version = "0.3.3" %}
-{% set sha256 = "4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e" %}
 
 package:
-  name: asciitree
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: asciitree-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/a/asciitree/asciitree-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 4aa4b9b649f85e3fcb343363d97564aa1fb62e249677f2e18a96765145cc0f6e
 
 build:
-  noarch: python
-  number: 2
-  script: python -m pip install --no-deps --ignore-installed .
+  number: 3
+  script: {{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv
 
 requirements:
   host:
     - pip
     - python
     - setuptools
-
   run:
     - python
 
 test:
   imports:
     - asciitree
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: http://github.com/mbr/asciitree
   license: MIT
+  license_family: MIT
   license_file: LICENSE
-  summary: 'Draws ASCII trees.'
+  summary: Draws ASCII trees.
+  description: Draws ASCII trees.
+  dev_url: http://github.com/mbr/asciitree
+  doc_url: http://github.com/mbr/asciitree
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
asciitree 0.3.3 

**Destination channel:** default

### Links

- [PKG-10030]
- dev_url:        https://github.com/mbr/asciitree/tree/0.3.3
- conda_forge:    https://github.com/conda-forge/asciitree-feedstock
- pypi:           https://pypi.org/project/asciitree/0.3.3
- pypi inspector: https://inspector.pypi.io/project/asciitree/0.3.3

### Explanation of changes:

- new version number


[PKG-10030]: https://anaconda.atlassian.net/browse/PKG-10030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ